### PR TITLE
Failing to call io_setup with EINVAL

### DIFF
--- a/drivers/tapdisk-utils.c
+++ b/drivers/tapdisk-utils.c
@@ -254,8 +254,12 @@ int tapdisk_linux_version(void)
 		return -errno;
 
 	n = sscanf(uts.release, "%u.%u.%u", &version, &patchlevel, &sublevel);
-	if (n != 3)
-		return -ENOSYS;
+	if (n != 3) {
+		n = sscanf(uts.release, "%u.%u", &version, &patchlevel);
+		if (n != 2)
+			return -ENOSYS;
+		sublevel = 0;
+	}
 
 	return KERNEL_VERSION(version, patchlevel, sublevel);
 }


### PR DESCRIPTION
Tapdisk fails to start and exits silently after failing
to detect current kernel version. This happens only on newer
kernel versions missing sublevel field.
