### PR TITLE
Various fixes

### DIFF
--- a/drivers/block-archipelago.c
+++ b/drivers/block-archipelago.c
@@ -535,6 +535,8 @@ err_exit:
     xseg_quit_local_signal(prv->xseg, prv->srcport);
     xseg_leave_dynport(prv->xseg, prv->port);
     xseg_leave(prv->xseg);
+    free(prv->segment_name);
+    free(prv->volname);
     return 0;
 }
 


### PR DESCRIPTION
- Remove useless type casting
- Destroy thread attributes object
- Free unused memory allocations on close
