### PR TITLE
Update debian package depenencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libs
 Priority: extra
 Maintainer: Chrysostomos Nanakos <cnanakos@grnet.gr>
 Build-Depends: debhelper (>= 8), autotools-dev, uuid-dev, libaio-dev, libtool,
- autoconf, automake, libxseg-dev(>>0.3.5)
+ autoconf, automake, libxseg-dev(>>0.4~rc1)
 Conflicts: blktap
 Replaces: blktap
 Standards-Version: 3.9.5
@@ -42,9 +42,11 @@ Description: Xen API blktap shared library (development files)
 Package: blktap-archipelago-utils
 Section: utils
 Architecture: i386 amd64
-Depends: ${misc:Depends}, ${shlibs:Depends}, libvhd0-archipelago (= ${binary:Version}),
- libvhdio-archipelago-2.1rc1 (= ${binary:Version}), libblktapctl0-archipelago (= ${binary:Version}),
- blktap-dkms, libxseg0(>>0.3.5), archipelago-protocol1
+Depends: ${misc:Depends}, ${shlibs:Depends},
+ libvhd0-archipelago (= ${binary:Version}),
+ libvhdio-archipelago-2.1rc1 (= ${binary:Version}),
+ libblktapctl0-archipelago (= ${binary:Version}),
+ blktap-dkms|blktap-dkms-bin, libxseg0(>>0.4~rc1), archipelago-protocol1
 Conflicts: blktap-utils
 Replaces: blktap-utils
 Description: utilities to work with VHD disk images files


### PR DESCRIPTION
Update debian package depenencies regarding libxseg and blktap-dkms. More
specifically:
- Blktap-archipelago now depends on libxseg >> 0.4rc1
- Blktap-archipelago-utils should depend on either blktap-dkms package or on a
  precompiled version.
